### PR TITLE
Upgrade standard to "^11.0.1"

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,10 +7,10 @@ module.exports = function (url, html, options) {
   const $ = cheerio.load(html)
   const scrapedMetaTags = extractMetaTags($)
   const metadata = new MetadataFields(options)
-                      .configureType(scrapedMetaTags['og:type'])
-                      .lockKeys()
-                      .set(scrapedMetaTags)
-                      .set({url: url})
+    .configureType(scrapedMetaTags['og:type'])
+    .lockKeys()
+    .set(scrapedMetaTags)
+    .set({url: url})
 
   // derive canonical url
   if (!metadata.get('canonical')) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "cheerio": "^0.22.0",
     "q": "^1.4.1",
     "request": "^2.75.0",
-    "standard": "^8.4.0",
     "underscore": "^1.8.3"
+  },
+  "devDependencies": {
+    "standard": "^11.0.1"
   }
 }


### PR DESCRIPTION
Standard linting tool had a vulnerability in previous versions (https://github.com/standard/standard/issues/995)